### PR TITLE
`index.html` now uses `main.js` as entry-point

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,17 +4,10 @@
 <head>
     <meta charset="utf-8" />
     <title>Yew</title>
+    <script src="/pkg/bundle.js" defer></script>
 </head>
 
 <body>
-    <script type="module">
-        import init, { run_app } from '/pkg/yew_wasm_pack_minimal.js';
-        async function main() {
-            await init('/pkg/yew_wasm_pack_minimal_bg.wasm');
-            run_app();
-        }
-        main()
-    </script>
 </body>
 
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,6 @@
+import init, { run_app } from './pkg/yew_wasm_pack_minimal.js';
+async function main() {
+   await init('/pkg/yew_wasm_pack_minimal_bg.wasm');
+   run_app();
+}
+main()


### PR DESCRIPTION
Removed entry-point shim code from `index.html` and moved it into
`main.js`